### PR TITLE
feat: internal event bus and buffer management fixes

### DIFF
--- a/doc/neoweaver.txt
+++ b/doc/neoweaver.txt
@@ -242,13 +242,15 @@ Notes:
 EXPLORER ~
 
 - Type: table
-- Default: `{ show_notifications = true }`
+- Default: `{ show_notifications = true, position = "left", size = 30 }`
 
-Controls explorer sidebar behavior.
+Controls explorer sidebar behavior and appearance.
 
 >lua
     explorer = {
       show_notifications = true,  -- Show notifications on refresh
+      position = "left",          -- "left" or "right"
+      size = 30,                  -- Width of the explorer sidebar
     }
 <
 
@@ -366,6 +368,10 @@ COMPLETE SETUP EXAMPLE        *neoweaver-configuration-complete-setup-example*
 >lua
     require('neoweaver').setup({
       allow_multiple_empty_notes = true,
+      explorer = {
+        position = "left",
+        size = 30,
+      },
       quicknotes = {
         title_template = "%Y%m%d%H%M",
         popup = {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,13 +97,15 @@ Notes:
 ### explorer
 
 - **Type:** table
-- **Default:** `{ show_notifications = true }`
+- **Default:** `{ show_notifications = true, position = "left", size = 30 }`
 
-Controls explorer sidebar behavior.
+Controls explorer sidebar behavior and appearance.
 
 ```lua
 explorer = {
   show_notifications = true,  -- Show notifications on refresh
+  position = "left",          -- "left" or "right"
+  size = 30,                  -- Width of the explorer sidebar
 }
 ```
 
@@ -200,6 +202,10 @@ Note: `.weaverc.json` does NOT contribute to note metadata. Only `.weaveroot.jso
 ```lua
 require('neoweaver').setup({
   allow_multiple_empty_notes = true,
+  explorer = {
+    position = "left",
+    size = 30,
+  },
   quicknotes = {
     title_template = "%Y%m%d%H%M",
     popup = {

--- a/lua/neoweaver/_internal/buffer/manager.lua
+++ b/lua/neoweaver/_internal/buffer/manager.lua
@@ -86,7 +86,7 @@ local function find_target_window()
     if buftype == "nofile" or filetype == "neoweaver_picker" then
       vim.api.nvim_set_current_win(win)
       local explorer = require("neoweaver._internal.explorer")
-      local split_cmd = explorer.get_position() == "right" and "leftabove vsplit" or "vsplit"
+      local split_cmd = explorer.get_position() == "left" and "rightbelow vsplit" or "leftabove vsplit"
       vim.cmd(split_cmd)
       local new_win = vim.api.nvim_get_current_win()
       return new_win

--- a/lua/neoweaver/_internal/buffer/manager.lua
+++ b/lua/neoweaver/_internal/buffer/manager.lua
@@ -78,13 +78,16 @@ local function find_target_window()
     end
   end
 
-  -- No suitable window - split from explorer if present
+  -- No suitable window - split from explorer/picker if present
   for _, win in ipairs(wins) do
     local buf = vim.api.nvim_win_get_buf(win)
+    local buftype = vim.api.nvim_get_option_value("buftype", { buf = buf })
     local filetype = vim.api.nvim_get_option_value("filetype", { buf = buf })
-    if filetype == "neoweaver_explorer" then
+    if buftype == "nofile" or filetype == "neoweaver_picker" then
       vim.api.nvim_set_current_win(win)
-      vim.cmd("vsplit")
+      local explorer = require("neoweaver._internal.explorer")
+      local split_cmd = explorer.get_position() == "right" and "leftabove vsplit" or "vsplit"
+      vim.cmd(split_cmd)
       local new_win = vim.api.nvim_get_current_win()
       return new_win
     end

--- a/lua/neoweaver/_internal/buffer/manager.lua
+++ b/lua/neoweaver/_internal/buffer/manager.lua
@@ -89,6 +89,8 @@ local function find_target_window()
       local split_cmd = explorer.get_position() == "left" and "rightbelow vsplit" or "leftabove vsplit"
       vim.cmd(split_cmd)
       local new_win = vim.api.nvim_get_current_win()
+      -- Restore explorer width after split
+      vim.api.nvim_win_set_width(win, explorer.get_size())
       return new_win
     end
   end

--- a/lua/neoweaver/_internal/collections/view.lua
+++ b/lua/neoweaver/_internal/collections/view.lua
@@ -7,8 +7,11 @@ local Input = require("nui.input")
 local manager = require("neoweaver._internal.picker.manager")
 local collections = require("neoweaver._internal.collections")
 local api = require("neoweaver._internal.api")
+local events = require("neoweaver._internal.events")
 
 local M = {}
+
+local ORIGIN = "collections"
 
 local function empty_stats()
   return { items = { { label = "Collections", count = 0 }, { label = "Notes", count = 0 } } }
@@ -256,6 +259,12 @@ M.source = {
                 return
               end
               vim.notify("Created collection: " .. collection.displayName, vim.log.levels.INFO)
+
+              events.emit(events.types.COLLECTION, {
+                action = "created",
+                collection = { id = collection.id, displayName = collection.displayName, parentId = parent_id },
+              }, { origin = ORIGIN })
+
               if refresh_cb then
                 refresh_cb()
               end
@@ -301,6 +310,12 @@ M.source = {
                 return
               end
               vim.notify("Renamed collection to: " .. collection.displayName, vim.log.levels.INFO)
+
+              events.emit(events.types.COLLECTION, {
+                action = "updated",
+                collection = { id = collection.id, displayName = collection.displayName },
+              }, { origin = ORIGIN })
+
               if refresh_cb then
                 refresh_cb()
               end
@@ -321,6 +336,12 @@ M.source = {
                   return
                 end
                 vim.notify("Renamed note to: " .. patch_res.data.title, vim.log.levels.INFO)
+
+                events.emit(events.types.NOTE, {
+                  action = "updated",
+                  note = { id = node.note_id, title = patch_res.data.title },
+                }, { origin = ORIGIN })
+
                 if refresh_cb then
                   refresh_cb()
                 end
@@ -357,6 +378,12 @@ M.source = {
                 return
               end
               vim.notify("Deleted collection: " .. node.name, vim.log.levels.INFO)
+
+              events.emit(events.types.COLLECTION, {
+                action = "deleted",
+                collection = { id = node.collection_id },
+              }, { origin = ORIGIN })
+
               if refresh_cb then
                 refresh_cb()
               end
@@ -369,6 +396,12 @@ M.source = {
                 return
               end
               vim.notify("Deleted note: " .. node.name, vim.log.levels.INFO)
+
+              events.emit(events.types.NOTE, {
+                action = "deleted",
+                note = { id = node.note_id },
+              }, { origin = ORIGIN })
+
               if refresh_cb then
                 refresh_cb()
               end

--- a/lua/neoweaver/_internal/config.lua
+++ b/lua/neoweaver/_internal/config.lua
@@ -8,6 +8,8 @@ M.defaults = {
   metadata = {},
   explorer = {
     show_notifications = true,
+    position = "left", -- "left" or "right"
+    size = 30,
   },
   quicknotes = { -- See issue #13
     title_template = "%Y%m%d%H%M",

--- a/lua/neoweaver/_internal/events.lua
+++ b/lua/neoweaver/_internal/events.lua
@@ -1,0 +1,119 @@
+--- Internal event bus for component coordination
+--- Handles both SSE events (from server) and local events (between components)
+
+local M = {}
+
+--- Event domain types
+M.types = {
+  -- SSE events (from server)
+  NOTE = "note",
+  COLLECTION = "collection",
+  TAG = "tag",
+  SYSTEM = "system",
+}
+
+--- Reserved origin for SSE events (bypasses origin filtering)
+local SSE_ORIGIN = "sse"
+
+---@class EventSubscriber
+---@field fn fun(event: table)
+---@field origin string|nil
+
+---@type table<string, EventSubscriber[]>
+local subscribers = {}
+
+--- Subscribe to domain events
+---@param domains string|string[] Event domains to subscribe to
+---@param callback fun(event: table) Called when event is dispatched
+---@param opts? { origin?: string } Origin identifier for filtering (e.g., "buffer", "collections")
+---@return fun() unsubscribe Cleanup function
+function M.on(domains, callback, opts)
+  if type(domains) == "string" then
+    domains = { domains }
+  end
+
+  opts = opts or {}
+  local subscriber = { fn = callback, origin = opts.origin }
+
+  for _, domain in ipairs(domains) do
+    if not subscribers[domain] then
+      subscribers[domain] = {}
+    end
+    table.insert(subscribers[domain], subscriber)
+  end
+
+  return function()
+    for _, domain in ipairs(domains) do
+      local subs = subscribers[domain]
+      if subs then
+        for i, sub in ipairs(subs) do
+          if sub == subscriber then
+            table.remove(subs, i)
+            break
+          end
+        end
+      end
+    end
+  end
+end
+
+--- Dispatch event to subscribers
+---@param event table Event with type, data, and optional origin
+local function dispatch(event)
+  local domain = event.type
+  if not domain then
+    return
+  end
+
+  local subs = subscribers[domain]
+  if not subs then
+    return
+  end
+
+  local event_origin = event.origin
+
+  for _, subscriber in ipairs(subs) do
+    -- Skip if origins match (unless SSE origin, which goes to everyone)
+    local should_skip = event_origin
+      and event_origin ~= SSE_ORIGIN
+      and subscriber.origin
+      and subscriber.origin == event_origin
+
+    if not should_skip then
+      local ok, err = pcall(subscriber.fn, event)
+      if not ok then
+        vim.notify("Event subscriber error: " .. tostring(err), vim.log.levels.ERROR)
+      end
+    end
+  end
+end
+
+--- Emit a local event (with origin filtering)
+---@param event_type string Domain type (e.g., "note", "collection")
+---@param data table Event data (action, entity details)
+---@param opts { origin: string } Source component identifier
+function M.emit(event_type, data, opts)
+  if not opts or not opts.origin then
+    vim.notify("events.emit: origin is required", vim.log.levels.WARN)
+    return
+  end
+
+  dispatch({
+    type = event_type,
+    data = data,
+    origin = opts.origin,
+  })
+end
+
+--- Dispatch SSE event from server (no origin filtering)
+--- Called by api.lua when SSE event arrives (already filtered by session_id)
+---@param event table Raw SSE event { event = string, data = table }
+function M.dispatch_sse(event)
+  dispatch({
+    type = event.event,
+    data = event.data,
+    origin = SSE_ORIGIN,
+  })
+end
+
+return M

--- a/lua/neoweaver/_internal/explorer/init.lua
+++ b/lua/neoweaver/_internal/explorer/init.lua
@@ -175,4 +175,9 @@ function M.get_position()
   return nw_config.get().explorer.position
 end
 
+---@return number
+function M.get_size()
+  return nw_config.get().explorer.size
+end
+
 return M

--- a/lua/neoweaver/_internal/explorer/init.lua
+++ b/lua/neoweaver/_internal/explorer/init.lua
@@ -2,6 +2,7 @@
 
 local Split = require("nui.split")
 local manager = require("neoweaver._internal.picker.manager")
+local nw_config = require("neoweaver._internal.config")
 
 local M = {}
 
@@ -12,13 +13,6 @@ local state = {
   current_view = nil,
   ---@type NuiSplit|nil
   split = nil,
-}
-
-local config = {
-  window = {
-    position = "left",
-    size = 30,
-  },
 }
 
 local WIN_OPTIONS = {
@@ -39,10 +33,11 @@ end
 
 ---@return NuiSplit
 local function create_split()
+  local cfg = nw_config.get().explorer
   return Split({
     relative = "editor",
-    position = config.window.position,
-    size = config.window.size,
+    position = cfg.position,
+    size = cfg.size,
     win_options = WIN_OPTIONS,
   })
 end
@@ -173,6 +168,11 @@ end
 ---@return boolean
 function M.is_mounted()
   return state.split ~= nil and state.split._.mounted
+end
+
+---@return "left"|"right"
+function M.get_position()
+  return nw_config.get().explorer.position
 end
 
 return M

--- a/lua/neoweaver/_internal/picker/init.lua
+++ b/lua/neoweaver/_internal/picker/init.lua
@@ -91,7 +91,7 @@ function Picker:onShow()
       if self.is_visible then
         self:refresh()
       end
-    end)
+    end, { origin = self.source.name })
   end
 end
 


### PR DESCRIPTION
## Summary
- Add internal pub/sub event bus for cross-component coordination (explorer ↔ buffer manager)
- Fix picker window hijacking when opening notes after main window closes
- Fix split direction to respect explorer position (left/right)

## Changes
- **New:** `lua/neoweaver/_internal/events.lua` - Event bus with origin-based filtering
- **Updated:** Buffer manager, collections view, notes module to emit/subscribe to events
- **Updated:** Explorer config centralized with `position` and `size` options
- **Fixed:** `find_target_window()` now correctly creates splits opposite to explorer position